### PR TITLE
Simplify the position penalty

### DIFF
--- a/mjpc/tasks/allegro/allegro.cc
+++ b/mjpc/tasks/allegro/allegro.cc
@@ -49,24 +49,6 @@ void Allegro::ResidualFn::Residual(const mjModel *model, const mjData *data,
 
   // difference between the cube position and goal position
   mju_sub3(residual + counter, cube_position, cube_goal_position);
-
-  // penalty if the cube's x dimension is outside the hand/on edges
-  // if (cube_position[0] < -0.07 + 0.25 || cube_position[0] > 0.01 + 0.25) {
-  //   residual[counter] *= 5.0;
-  // }
-  if (cube_position[0] < -0.1 + 0.25 || cube_position[0] > 0.03 + 0.25) {
-    residual[counter] *= 5.0;
-  }
-
-  // penalty if the cube's y dimension is near edges
-  if (cube_position[1] < -0.04 || cube_position[1] > 0.03) {
-    residual[counter + 1] *= 5.0;
-  }
-
-  // penalty if the cube's z height is below the palm
-  if (cube_position[2] < -0.03) {
-    residual[counter + 2] *= 5.0;
-  }
   counter += 3;
 
   // ---------- Cube orientation ----------

--- a/mjpc/tasks/allegro/task.xml
+++ b/mjpc/tasks/allegro/task.xml
@@ -78,8 +78,7 @@
 
   <sensor>
     <!-- Residuals -->
-    <user name="Cube Position" dim="3" user="1 100 0 100 0.02 2"/>
-    <!-- <user name="Cube Position" dim="3" user="0 50 0 100"/> -->
+    <user name="Cube Position" dim="3" user="1 500 0 1000 0.04 50"/>
     <user name="Cube Orientation" dim="3" user="0 15.0 0 100" />
     <user name="Cube Velocity" dim="3" user="0 0 0 20" />
     <user name="Actuation" dim="16" user="0 0 0.0 10" />


### PR DESCRIPTION
Simplifies the position penalty for the allegro cube example. The new position cost is basically zero when the cube is within 4cm of the target, and super large otherwise. 

I tested this on my laptop with vanilla predictive sampling and 10 rollouts. With those settings it's comparable to what we had before: I'm able to get 15-20 rotations with perfect state estimation, and fewer with noise. Failures come almost exclusively from timing out rather than dropping the cube. 

I haven't tested this with CEM or on a machine that can handle lots of rollouts.